### PR TITLE
Ignore python caches.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 # Created by .ignore support plugin (hsz.mobi)
-### Example user template template
-### Example user template
 
 # IntelliJ project files
 .idea
@@ -8,3 +6,5 @@
 out
 gen
 
+# Caches
+__pycache__


### PR DESCRIPTION
We do not need to track the auto-generated cache files in version control.