### PR TITLE
Specify proper types in ArgumentParser

### DIFF
--- a/evaluate_attack_cifar10.py
+++ b/evaluate_attack_cifar10.py
@@ -16,7 +16,7 @@ import numpy as np
 parser = argparse.ArgumentParser(description='PyTorch CIFAR Attack Evaluation')
 parser.add_argument('--no-cuda', action='store_true', default=False,
                     help='disables CUDA training')
-parser.add_argument('--epsilon', default=0.031,
+parser.add_argument('--epsilon', type=float, default=0.031,
                     help='perturbation')
 parser.add_argument('--model-path',
                     default='./checkpoints/model_cifar_wrn.pt',

--- a/evaluate_attack_mnist.py
+++ b/evaluate_attack_mnist.py
@@ -9,7 +9,7 @@ import numpy as np
 parser = argparse.ArgumentParser(description='PyTorch MNIST Attack Evaluation')
 parser.add_argument('--no-cuda', action='store_true', default=False,
                     help='disables CUDA training')
-parser.add_argument('--epsilon', default=0.3,
+parser.add_argument('--epsilon', type=float, default=0.3,
                     help='perturbation')
 parser.add_argument('--model-path',
                     default='./checkpoints/model_mnist_smallcnn.pt',

--- a/mnist_example_trades.py
+++ b/mnist_example_trades.py
@@ -86,13 +86,13 @@ def main():
                         help='SGD momentum (default: 0.5)')
     parser.add_argument('--no-cuda', action='store_true', default=False,
                         help='disables CUDA training')
-    parser.add_argument('--epsilon', default=0.1,
+    parser.add_argument('--epsilon', type=float, default=0.1,
                         help='perturbation')
-    parser.add_argument('--num-steps', default=10,
+    parser.add_argument('--num-steps', type=int, default=10,
                         help='perturb number of steps')
-    parser.add_argument('--step-size', default=0.02,
+    parser.add_argument('--step-size', type=float, default=0.02,
                         help='perturb step size')
-    parser.add_argument('--beta', default=1.0,
+    parser.add_argument('--beta', type=float, default=1.0,
                         help='regularization, i.e., 1/lambda in TRADES')
     parser.add_argument('--seed', type=int, default=1, metavar='S',
                         help='random seed (default: 1)')

--- a/pgd_attack_cifar10.py
+++ b/pgd_attack_cifar10.py
@@ -17,13 +17,13 @@ parser.add_argument('--test-batch-size', type=int, default=200, metavar='N',
                     help='input batch size for testing (default: 200)')
 parser.add_argument('--no-cuda', action='store_true', default=False,
                     help='disables CUDA training')
-parser.add_argument('--epsilon', default=0.031,
+parser.add_argument('--epsilon', type=float, default=0.031,
                     help='perturbation')
-parser.add_argument('--num-steps', default=20,
+parser.add_argument('--num-steps', type=int, default=20,
                     help='perturb number of steps')
-parser.add_argument('--step-size', default=0.003,
+parser.add_argument('--step-size', type=float, default=0.003,
                     help='perturb step size')
-parser.add_argument('--random',
+parser.add_argument('--random', action='store_true',
                     default=True,
                     help='random initialization for PGD')
 parser.add_argument('--model-path',
@@ -35,7 +35,7 @@ parser.add_argument('--source-model-path',
 parser.add_argument('--target-model-path',
                     default='./checkpoints/model_cifar_wrn.pt',
                     help='target model for black-box attack evaluation')
-parser.add_argument('--white-box-attack', default=True,
+parser.add_argument('--white-box-attack', action='store_true', default=True,
                     help='whether perform white-box attack')
 
 args = parser.parse_args()

--- a/pgd_attack_mnist.py
+++ b/pgd_attack_mnist.py
@@ -17,13 +17,13 @@ parser.add_argument('--test-batch-size', type=int, default=200, metavar='N',
                     help='input batch size for testing (default: 200)')
 parser.add_argument('--no-cuda', action='store_true', default=False,
                     help='disables CUDA training')
-parser.add_argument('--epsilon', default=0.3,
+parser.add_argument('--epsilon', type=float, default=0.3,
                     help='perturbation')
-parser.add_argument('--num-steps', default=40,
+parser.add_argument('--num-steps', type=int, default=40,
                     help='perturb number of steps')
-parser.add_argument('--step-size', default=0.01,
+parser.add_argument('--step-size', type=float, default=0.01,
                     help='perturb step size')
-parser.add_argument('--random',
+parser.add_argument('--random', action='store_true',
                     default=True,
                     help='random initialization for PGD')
 parser.add_argument('--model-path',
@@ -35,7 +35,7 @@ parser.add_argument('--source-model-path',
 parser.add_argument('--target-model-path',
                     default='./checkpoints/model_mnist_smallcnn.pt',
                     help='target model for black-box attack evaluation')
-parser.add_argument('--white-box-attack', default=True,
+parser.add_argument('--white-box-attack', action='store_true', default=True,
                     help='whether perform white-box attack')
 
 args = parser.parse_args()

--- a/train_trades_cifar10.py
+++ b/train_trades_cifar10.py
@@ -27,13 +27,13 @@ parser.add_argument('--momentum', type=float, default=0.9, metavar='M',
                     help='SGD momentum')
 parser.add_argument('--no-cuda', action='store_true', default=False,
                     help='disables CUDA training')
-parser.add_argument('--epsilon', default=0.031,
+parser.add_argument('--epsilon', type=float, default=0.031,
                     help='perturbation')
-parser.add_argument('--num-steps', default=10,
+parser.add_argument('--num-steps', type=int, default=10,
                     help='perturb number of steps')
-parser.add_argument('--step-size', default=0.007,
+parser.add_argument('--step-size', type=float, default=0.007,
                     help='perturb step size')
-parser.add_argument('--beta', default=6.0,
+parser.add_argument('--beta', type=float, default=6.0,
                     help='regularization, i.e., 1/lambda in TRADES')
 parser.add_argument('--seed', type=int, default=1, metavar='S',
                     help='random seed (default: 1)')

--- a/train_trades_mnist.py
+++ b/train_trades_mnist.py
@@ -25,13 +25,13 @@ parser.add_argument('--momentum', type=float, default=0.9, metavar='M',
                     help='SGD momentum')
 parser.add_argument('--no-cuda', action='store_true', default=False,
                     help='disables CUDA training')
-parser.add_argument('--epsilon', default=0.3,
+parser.add_argument('--epsilon', type=float, default=0.3,
                     help='perturbation')
-parser.add_argument('--num-steps', default=40,
+parser.add_argument('--num-steps', type=int, default=40,
                     help='perturb number of steps')
-parser.add_argument('--step-size', default=0.01,
+parser.add_argument('--step-size', type=float, default=0.01,
                     help='perturb step size')
-parser.add_argument('--beta', default=1.0,
+parser.add_argument('--beta', type=float, default=1.0,
                     help='regularization, i.e., 1/lambda in TRADES')
 parser.add_argument('--seed', type=int, default=1, metavar='S',
                     help='random seed (default: 1)')

--- a/train_trades_mnist_binary.py
+++ b/train_trades_mnist_binary.py
@@ -23,13 +23,13 @@ parser.add_argument('--momentum', type=float, default=0.9, metavar='M',
                     help='SGD momentum')
 parser.add_argument('--no-cuda', action='store_true', default=False,
                     help='disables CUDA training')
-parser.add_argument('--epsilon', default=0.1,
+parser.add_argument('--epsilon', type=float, default=0.1,
                     help='perturbation')
-parser.add_argument('--num-steps', default=20,
+parser.add_argument('--num-steps', type=int, default=20,
                     help='perturb number of steps')
-parser.add_argument('--step-size', default=0.01,
+parser.add_argument('--step-size', type=float, default=0.01,
                     help='perturb step size')
-parser.add_argument('--beta', default=5.0,
+parser.add_argument('--beta', type=float, default=5.0,
                     help='regularization, i.e., lambda in TRADES for binary case')
 parser.add_argument('--weight-decay', '--wd', default=0.0,
                     type=float, metavar='W', help='weight decay')


### PR DESCRIPTION
Hi, please take a second to review my pull request.

Certain variables passed into argparse.ArgumentParser() (epsilon, num-steps, ...) need their types to be specified. Otherwise, changing them from their default values leads to errors, since they're automatically interpreted as strings instead.

Thank you,
Momin